### PR TITLE
build(deps): update Spring Boot/Cloud and gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![ETEREA.gateway-service CI](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml)
 [![Documentation Status](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/pages.yml/badge.svg)](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/pages.yml)
 [![Java Version](https://img.shields.io/badge/Java-24-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.4.5-green.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2024.0.1-blue.svg)](https://spring.io/projects/spring-cloud)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.3-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Description
@@ -77,9 +77,10 @@ The service exposes health endpoints via Spring Boot Actuator:
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Recent Changes
+- **v1.1.0 Release**
 - Implemented advanced monitoring and metrics system
 - Updated dependencies and improved infrastructure
-- Updated to Java 24 and Spring Boot 3.4.5
+- Updated to Java 24 and Spring Boot 3.5.3
 - Added automated documentation generation
 - Implemented GitHub Pages for documentation
 - Added wiki generation scripts

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -21,34 +21,36 @@ spring:
     name: ${app.name}
   cloud:
     gateway:
-      discovery:
-        locator:
-          enabled: true
-      routes:
-        - id: report-service
-          uri: lb://report-service
-          predicates:
-            - Path=/api/report/**
-        - id: core-service
-          uri: lb://core-service
-          predicates:
-            - Path=/api/core/**
-        - id: pyafipws-service
-          uri: lb://pyafipws-service
-          predicates:
-            - Path=/api/afipws/**
-        - id: stock-service
-          uri: lb://stock-service
-          predicates:
-            - Path=/api/stock/**
-        - id: programa-dia-service
-          uri: lb://programa-dia-service
-          predicates:
-            - Path=/api/programa-dia/**
-        - id: isolate-service
-          uri: lb://isolate-service
-          predicates:
-            - Path=/api/isolate/**
+      server:
+        webflux:
+          discovery:
+            locator:
+              enabled: true
+          routes:
+            - id: report-service
+              uri: lb://report-service
+              predicates:
+                - Path=/api/report/**
+            - id: core-service
+              uri: lb://core-service
+              predicates:
+                - Path=/api/core/**
+            - id: pyafipws-service
+              uri: lb://pyafipws-service
+              predicates:
+                - Path=/api/afipws/**
+            - id: stock-service
+              uri: lb://stock-service
+              predicates:
+                - Path=/api/stock/**
+            - id: programa-dia-service
+              uri: lb://programa-dia-service
+              predicates:
+                - Path=/api/programa-dia/**
+            - id: isolate-service
+              uri: lb://isolate-service
+              predicates:
+                - Path=/api/isolate/**
 
 logging:
   level:


### PR DESCRIPTION
## Descripción
Este Pull Request actualiza las dependencias de Spring Boot y Spring Cloud, y ajusta la configuración del gateway para la versión 1.1.0. Resuelve la issue #21.

## Cambios Realizados
- Actualización de las versiones de Spring Boot (a 3.5.3) y Spring Cloud (a 2025.0.0) en `README.md`.
- Adición de la entrada "v1.1.0 Release" en la sección de "Recent Changes" del `README.md`.
- Refactorización de la configuración del gateway en `src/main/resources/bootstrap.yml`, moviendo `discovery.locator` y `routes` bajo `server.webflux` para alinearse con las nuevas versiones.

## Impacto Potencial
- Los cambios en la configuración del gateway podrían requerir una revisión cuidadosa para asegurar que el enrutamiento y el descubrimiento de servicios sigan funcionando como se espera.

## Verificación
1.  Asegúrate de estar en la rama `21-release-v110-readme-and-gateway-configuration-updates`.
2.  Construye el proyecto: `mvn clean install`
3.  Ejecuta el servicio: `mvn spring-boot:run`
4.  Verifica que el gateway se inicie correctamente y que las rutas configuradas sean accesibles.
5.  Revisa el `README.md` para confirmar las versiones actualizadas.

## Notas Adicionales
Este PR es parte del proceso de lanzamiento de la versión 1.1.0.
