### PR TITLE
feat(config): migrar de Eureka a Consul y actualizar configuración para release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-07-24
+### Changed
+- Se reemplazó el sistema de descubrimiento de servicios: **de Eureka a Consul**.
+- Actualización de la configuración en `bootstrap.yml` para soportar Consul.
+- Cambio del nombre del proyecto a "ETEREA.gateway-service" en `pom.xml`.
+
+### Removed
+- Eliminada la dependencia de `spring-cloud-starter-netflix-eureka-client`.
+- Eliminada la configuración de Eureka en los archivos de configuración.
+
+### Notes
+- Este cambio es incompatible con versiones anteriores que dependían de Eureka para el descubrimiento de servicios.
+
 ## [1.2.0] - 2025-07-21
 ### Added
 - Integración con SonarCloud para análisis de calidad de código.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ETEREA.gateway-service
 
-[![ETEREA.gateway-service Build JVM Image](https://github.com/ETEREa-services/ETEREA.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml)
+[![ETEREA.gateway-service Build JVM Image](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml)
 [![Java Version](https://img.shields.io/badge/Java-24-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.3-green.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
@@ -18,7 +18,7 @@ ETEREA.gateway-service is a Spring Cloud Gateway service that acts as the entry 
 ## Features
 - Dynamic service routing
 - Load balancing with Spring Cloud LoadBalancer
-- Service discovery with Eureka
+- **Service discovery with Consul**
 - CORS configuration
 - Health monitoring with Spring Boot Actuator
 - Caffeine cache for optimized load balancing
@@ -50,14 +50,14 @@ mvn spring-boot:run
 ### Docker
 Build and run with Docker:
 ```bash
-docker build -t eterea-gateway-service:1.2.0 .
-docker run -p 8080:8080 eterea-gateway-service:1.2.0
+docker build -t eterea-gateway-service:2.0.0 .
+docker run -p 8080:8080 eterea-gateway-service:2.0.0
 ```
 
 ## Configuration
 The service can be configured through `application.yml` or environment variables. Key configurations include:
 - Server port
-- Service discovery settings
+- **Consul service discovery settings**
 - Route definitions
 - CORS policies
 - Load balancer settings
@@ -83,6 +83,12 @@ The service exposes health endpoints via Spring Boot Actuator:
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Recent Changes
+- **v2.0.0 Release**
+- Changed: Se reemplazó el sistema de descubrimiento de servicios de Eureka a Consul.
+- Changed: Actualización de la configuración en `bootstrap.yml` para soportar Consul.
+- Changed: Cambio del nombre del proyecto a "ETEREA.gateway-service" en `pom.xml`.
+- Removed: Eliminada la dependencia de `spring-cloud-starter-netflix-eureka-client`.
+- Removed: Eliminada la configuración de Eureka en los archivos de configuración.
 - **v1.2.0 Release**
 - Added: Integración con SonarCloud para análisis de calidad de código.
 - Changed: Refactorización del workflow de CI/CD para construcción de imágenes JVM, incluyendo login a Docker Hub y etiquetado semántico.
@@ -90,19 +96,6 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 - Removed: Eliminación de los scripts del Maven Wrapper (`mvnw`, `mvnw.cmd`).
 - Removed: Eliminación de `Dockerfile.local`.
 - Removed: Eliminación de `pages.png`.
-- **v1.1.2 Release**
-- Fix(docs): repair the structure of index.html in the workflow
-- Fix(docs): correct the generation of data.js in the workflow
-- **v1.1.1 Release**
-- Build(deps): update Spring Boot/Cloud and gateway config
-- **v1.1.0 Release**
-- Implemented advanced monitoring and metrics system
-- Updated dependencies and improved infrastructure
-- Updated to Java 24 and Spring Boot 3.5.3
-- Added automated documentation generation
-- Implemented GitHub Pages for documentation
-- Added wiki generation scripts
-- Improved CI/CD infrastructure
 
 ## Contact
 ETEREA Services Team

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>com.termascacheuta.eterea</groupId>
 	<artifactId>gateway-service</artifactId>
 	<version>1.2.0</version>
-	<name>eterea.gateway-service</name>
+	<name>ETEREA.gateway-service</name>
 	<description>gateway-service</description>
 	<url/>
 	<licenses>
@@ -49,7 +49,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+			<artifactId>spring-cloud-starter-consul-discovery</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,25 +1,24 @@
 app:
   port: ${APP_PORT:8080}
-  eureka: 8761
   logging: debug
   name: gateway-service
+  consul:
+    host: consul-service
+    port: 8500
 
 server:
   port: ${app.port}
-
-eureka:
-  instance:
-    prefer-ip-address: true
-  client:
-    fetch-registry: true
-    register-with-eureka: true
-    service-url:
-      defaultZone: http://eureka:@eureka-service:${app.eureka}/eureka
 
 spring:
   application:
     name: ${app.name}
   cloud:
+    consul:
+      host: ${app.consul.host}
+      port: ${app.consul.port}
+      discovery:
+        prefer-ip-address: true
+        tags: eterea,gateway
     gateway:
       server:
         webflux:


### PR DESCRIPTION
## Descripción
Este Pull Request migra el sistema de descubrimiento de servicios de Eureka a Consul, actualiza la configuración y dependencias necesarias, y documenta el cambio en los archivos principales del proyecto. Resuelve la issue #33.

## Cambios Realizados
- [x] Se reemplazó la dependencia de `spring-cloud-starter-netflix-eureka-client` por `spring-cloud-starter-consul-discovery` en `pom.xml`.
- [x] Se eliminó la configuración de Eureka y se añadió la de Consul en `bootstrap.yml`.
- [x] Se actualizó el nombre del proyecto en `pom.xml`.
- [x] Se actualizaron y documentaron los cambios en `README.md` y `CHANGELOG.md` para reflejar la nueva arquitectura y el release 2.0.0.

## Impacto Potencial
- [x] Cambios incompatibles: el gateway ahora requiere Consul en vez de Eureka para el descubrimiento de servicios.
- [x] Es necesario actualizar la infraestructura y la configuración de despliegue para soportar Consul.

## Verificación
1. `git checkout 33-cambios-mayores-migración-de-eureka-a-consul-y-actualización-de-configuración`
2. `mvn clean install`
3. Configurar y levantar un servidor Consul accesible según la configuración de `bootstrap.yml`.
4. Ejecutar la aplicación y verificar el registro y descubrimiento de servicios vía Consul.
5. Revisar los endpoints de health y la documentación generada.

## Notas Adicionales
- Este cambio es crítico para la interoperabilidad futura del ecosistema ETEREA.
- Se recomienda revisar la documentación de despliegue y actualizar los entornos de integración y producción antes de hacer merge.
