### PR TITLE
build(deps): upgrade Spring Boot to 4.0.6 and Java to 25

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,21 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
       - name: Generate Dependency Tree
-        run: |
-          mkdir -p public
-          mvn dependency:tree -DoutputFile=public/dependency-tree.txt
+        run: mvn dependency:tree -DoutputFile=docs/dependency-tree.txt
 
       - name: Generate Project Documentation
         env:
@@ -43,13 +41,11 @@ jobs:
           curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/issues?state=all&per_page=100" > issues.json
           curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/pulls?state=all&per_page=100" > prs.json
           
-          echo "const milestonesData = $(cat milestones.json);" > public/data.js
-          echo "const issuesData = $(cat issues.json);" >> public/data.js
-          echo "const prsData = $(cat prs.json);" >> public/data.js
+          echo "const milestonesData = $(cat milestones.json);" > docs/data.js
+          echo "const issuesData = $(cat issues.json);" >> docs/data.js
+          echo "const prsData = $(cat prs.json);" >> docs/data.js
 
-          cp -r docs/diagrams public/diagrams
-
-          cat > public/index.html << 'EOF'
+          cat > docs/index.html << 'EOF'
           <!DOCTYPE html>
           <html lang="es">
           <head>
@@ -127,20 +123,17 @@ jobs:
                               
                               subgraph "Eterea Ecosystem"
                                   Gateway(Eterea API Gateway)
-                                  Auth[Servicio de Autenticación]
+                                  Consul[Consul Discovery]
                                   Users[Servicio de Usuarios]
                                   Products[Servicio de Productos]
-                                  Discovery[Servicio de Discovery]
                               end
 
                               Client -- HTTPS --> Gateway
-                              Gateway -- Valida Token --> Auth
                               Gateway -- Enruta Petición --> Users
                               Gateway -- Enruta Petición --> Products
-                              Gateway -- Descubre Servicios --> Discovery
-                              Auth -- Se registra en --> Discovery
-                              Users -- Se registra en --> Discovery
-                              Products -- Se registra en --> Discovery
+                              Gateway -- Descubre Servicios --> Consul
+                              Users -- Se registra en --> Consul
+                              Products -- Se registra en --> Consul
                       </div>
                   `;
                   document.getElementById('architecture').innerHTML = architectureHTML;
@@ -254,9 +247,9 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: public
+          path: docs
 
   deploy-pages:
     needs: generate-docs
@@ -271,4 +264,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2.2.0] - 2026-05-27
+### Changed
+- build(deps): Actualización de Spring Boot de 3.5.6 a 4.0.6
+- build(deps): Actualización de Java de 24 a 25
+- build(deps): Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- ci(actions): Actualización de GitHub Actions a versiones superiores (checkout v6, setup-java v5, cache v5, deploy-pages v5)
+- ci(docker): Actualización de imágenes base Docker a JDK 25
+- docs(pipeline): Corrección de ruta de salida de documentación de `public/` a `docs/`
+
 ## [2.1.0] - 2025-09-21
 ### Added
 - feat(logging): Added LoggingGlobalFilter for comprehensive request and response logging
@@ -12,6 +21,14 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 ### Changed
 - build(deps): Updated Spring Boot starter parent from 3.5.4 to 3.5.6
 
+## [2.0.1] - 2025-08-05
+### Changed
+- Actualización de la dependencia `spring-boot-starter-parent` de la versión `3.5.3` a `3.5.4` en `pom.xml`.
+- Implementación de Dockerfile multi-etapa para optimizar el tamaño de la imagen y mejorar la seguridad con usuario no privilegiado.
+
+### Removed
+- Eliminación de `Dockerfile.local`.
+- Eliminación de `pages.png`.
 
 ## [2.0.0] - 2025-07-24
 ### Changed
@@ -29,14 +46,6 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 ## [1.2.0] - 2025-07-21
 ### Added
 - Refactorización del workflow de CI/CD para construcción de imágenes JVM, incluyendo login a Docker Hub y etiquetado semántico.
-[2.0.1] - 2025-08-05
-### Changed
-- Actualización de la dependencia `spring-boot-starter-parent` de la versión `3.5.3` a `3.5.4` en `pom.xml`.
-- Implementación de Dockerfile multi-etapa para optimizar el tamaño de la imagen y mejorar la seguridad con usuario no privilegiado.
-
-### Removed
-- Eliminación de `Dockerfile.local`.
-- Eliminación de `pages.png`.
 
 ## [1.1.2] - 2025-07-06
 ### Fixed
@@ -124,6 +133,9 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Configuración básica de Maven
 - Estructura inicial del proyecto
 
+[2.2.0]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v2.0.1...v2.1.0
+[2.0.1]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v2.0.0...v2.0.1
 [1.2.0]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/ETEREA-services/ETEREA.gateway-service/compare/v1.1.0...v1.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ETEREA.gateway-service
 
 [![ETEREA.gateway-service Build JVM Image](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.gateway-service/actions/workflows/maven.yml)
-[![Java Version](https://img.shields.io/badge/Java-24-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-green.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
+[![Java Version](https://img.shields.io/badge/Java-25-blue.svg)](https://www.oracle.com/java/technologies/downloads/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-green.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![SonarCloud Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=ETEREA-services_ETEREA.gateway-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ETEREA-services_ETEREA.gateway-service)
 [![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=ETEREA-services_ETEREA.gateway-service&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ETEREA-services_ETEREA.gateway-service)
@@ -26,7 +26,7 @@ ETEREA.gateway-service is a Spring Cloud Gateway service that acts as the entry 
 - SonarCloud integration for code quality analysis
 
 ## Prerequisites
-- Java 24
+- Java 25
 - Maven 3.x
 - Docker (optional)
 
@@ -51,8 +51,8 @@ mvn spring-boot:run
 ### Docker
 Build and run with Docker:
 ```bash
-docker build -t eterea-gateway-service:2.1.0 .
-docker run -p 8080:8080 eterea-gateway-service:2.0.1
+docker build -t eterea-gateway-service:2.2.0 .
+docker run -p 8080:8080 eterea-gateway-service:2.2.0
 ```
 
 ## Configuration
@@ -84,6 +84,11 @@ The service exposes health endpoints via Spring Boot Actuator:
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Recent Changes
+- **v2.2.0 Release**
+- Changed: Actualización de Spring Boot de 3.5.6 a 4.0.6
+- Changed: Actualización de Java de 24 a 25
+- Changed: Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- Changed: Actualización de GitHub Actions a versiones superiores
 - **v2.1.0 Release**
 - Added: Request/response logging with LoggingGlobalFilter
 - Added: New route for lista-precio-proxy service

--- a/docs/diagrams/request-flow.mmd
+++ b/docs/diagrams/request-flow.mmd
@@ -1,12 +1,12 @@
 sequenceDiagram
     participant Client as Cliente
     participant Gateway as API Gateway
-    participant Auth as Servicio de Autenticación
+    participant Consul as Consul Discovery
     participant Service as Microservicio X
 
     Client->>+Gateway: GET /api/servicio-x/recurso
-    Gateway->>+Auth: Validar token
-    Auth-->>-Gateway: Token Válido
+    Gateway->>+Consul: Descubrir servicio
+    Consul-->>-Gateway: URI de servicio
     Gateway->>+Service: GET /recurso
     Service-->>-Gateway: Respuesta (Datos)
     Gateway-->>-Client: Respuesta (Datos)

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>4.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.termascacheuta.eterea</groupId>
 	<artifactId>gateway-service</artifactId>
-	   <version>2.1.0</version>
+	   <version>2.2.0</version>
 	<name>ETEREA.gateway-service</name>
 	<description>gateway-service</description>
 	<url/>
@@ -27,12 +27,15 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>24</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
+		<java.version>25</java.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 		<sonar.organization>eterea-services</sonar.organization>
 		<sonar.projectKey>ETEREA-services_ETEREA.gateway-service</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml
+		</sonar.coverage.jacoco.xmlReportPaths>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Closes #39

## Descripción
Release 2.2.0 con actualización mayor de dependencias: migración de Spring Boot 3.5.6 a 4.0.6, Java 24 a 25, y Spring Cloud 2025.0.0 a 2025.1.0. Se actualizaron las GitHub Actions y se corrigió la ruta de salida de documentación.

## Cambios Realizados
- build(deps): Actualización de Spring Boot de 3.5.6 a 4.0.6
- build(deps): Actualización de Java de 24 a 25
- build(deps): Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
- ci(actions): Actualización de GitHub Actions (checkout v6, setup-java v5, cache v5, deploy-pages v5)
- ci(docker): Actualización de imágenes base Docker a JDK 25
- docs(pipeline): Corrección de ruta de salida de documentación de `public/` a `docs/`
- docs(changelog): Actualización de CHANGELOG.md para versión 2.2.0
- docs(readme): Actualización de badges, prerequisitos y ejemplos Docker

## Verificación
- [ ] Verificar compilación con `mvn clean verify`
- [ ] Verificar que los workflows de CI/CD se ejecuten correctamente
- [ ] Verificar generación de documentación en ruta `docs/`
- [ ] Verificar构建 de imagen Docker
